### PR TITLE
Expand quantum utilities and add advanced framework skeleton

### DIFF
--- a/Readme
+++ b/Readme
@@ -10,9 +10,11 @@ This repository demonstrates a minimal quantum circuit simulator written in Pyth
 - Register-wide measurement utilities
 - Quantum Fourier Transform utilities
 - Controlled modular exponentiation (placeholder logic)
+- Small phase estimation routine
 - Example algorithms:
   - Shor's factoring method (`src/shor.py`)
   - Grover's search demo (`src/grover_example.py`)
+  - Phase estimation demo (`src/phase_estimation_example.py`)
     with configurable iteration count
 
 ## Running
@@ -23,6 +25,10 @@ Install the dependency and execute the examples:
 pip install numpy==1.26.4
 python3 src/shor.py        # Shor's algorithm
 python3 src/grover_example.py  # Grover's search
+python3 src/phase_estimation_example.py  # Phase estimation
 ```
 
 The simulator handles only very small integers but forms the basis for more sophisticated experiments.
+
+An experimental skeleton for a cutting-edge quantum framework lives under
+`src/quantum/advanced` and will be extended in future work.

--- a/src/algorithms/__init__.py
+++ b/src/algorithms/__init__.py
@@ -1,5 +1,6 @@
 """Quantum algorithm implementations."""
 
 from .grover import grover_search, example_usage
+from .phase_estimation import estimate_phase
 
-__all__ = ["grover_search", "example_usage"]
+__all__ = ["grover_search", "example_usage", "estimate_phase"]

--- a/src/algorithms/phase_estimation.py
+++ b/src/algorithms/phase_estimation.py
@@ -1,0 +1,35 @@
+"""Basic phase estimation using a rotation gate as the unitary."""
+
+import numpy as np
+
+from quantum import H, X, RZ, QuantumCircuit
+from quantum.transform import apply_inverse_qft
+
+
+def estimate_phase(theta: float, precision: int = 3) -> str:
+    """Estimate the phase ``theta`` using ``precision`` qubits."""
+    qc = QuantumCircuit(precision + 1)
+
+    # Prepare eigenstate |1> of RZ
+    qc.apply_gate(X, [precision])
+
+    for q in range(precision):
+        qc.apply_gate(H, [q])
+
+    for q in range(precision):
+        angle = 2 ** q * theta
+        qc.apply_controlled_gate(RZ(angle), q, precision)
+
+    qc.state = apply_inverse_qft(qc.state, precision, precision + 1)
+    result = qc.measure_all()
+    return result
+
+
+def example_usage():
+    theta = np.pi / 4
+    bits = estimate_phase(theta, precision=3)
+    print(f"Estimated phase for theta={theta}: {bits}")
+
+
+if __name__ == "__main__":
+    example_usage()

--- a/src/phase_estimation_example.py
+++ b/src/phase_estimation_example.py
@@ -1,0 +1,11 @@
+"""Demonstration script for quantum phase estimation."""
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from algorithms.phase_estimation import example_usage
+
+if __name__ == "__main__":
+    example_usage()

--- a/src/quantum/__init__.py
+++ b/src/quantum/__init__.py
@@ -1,6 +1,6 @@
 """Quantum computing utilities for custom algorithms."""
 
-from .gates import H, X, I, CNOT, S, T
+from .gates import H, X, I, CNOT, S, T, RZ
 from .circuit import QuantumCircuit
 
-__all__ = ["H", "X", "I", "CNOT", "S", "T", "QuantumCircuit"]
+__all__ = ["H", "X", "I", "CNOT", "S", "T", "RZ", "QuantumCircuit"]

--- a/src/quantum/advanced/__init__.py
+++ b/src/quantum/advanced/__init__.py
@@ -1,0 +1,16 @@
+"""Experimental advanced modules for future quantum features."""
+
+from .compiler import QuantumCompiler
+from .error_correction import SurfaceCode, StabilizerMeasurement
+from .noise_models import NoiseModel, DepolarizingChannel
+from .variational import VariationalCircuit, Optimizer
+
+__all__ = [
+    "QuantumCompiler",
+    "SurfaceCode",
+    "StabilizerMeasurement",
+    "NoiseModel",
+    "DepolarizingChannel",
+    "VariationalCircuit",
+    "Optimizer",
+]

--- a/src/quantum/advanced/compiler.py
+++ b/src/quantum/advanced/compiler.py
@@ -1,0 +1,11 @@
+"""Prototype compiler translating circuits to hardware instructions."""
+
+from quantum import QuantumCircuit
+
+
+class QuantumCompiler:
+    """Experimental quantum compiler interface."""
+
+    def compile(self, circuit: QuantumCircuit):
+        """Compile ``circuit`` to hardware-specific instructions."""
+        raise NotImplementedError

--- a/src/quantum/advanced/error_correction.py
+++ b/src/quantum/advanced/error_correction.py
@@ -1,0 +1,26 @@
+"""Placeholders for advanced error correction techniques."""
+
+from quantum import QuantumCircuit
+
+
+class SurfaceCode:
+    """Prototype for a surface code implementation."""
+
+    def __init__(self, distance: int):
+        self.distance = distance
+
+    def encode(self, circuit: QuantumCircuit) -> None:
+        """Encode ``circuit`` using the surface code."""
+        raise NotImplementedError
+
+    def decode(self, syndrome):
+        """Return a correction based on ``syndrome``."""
+        raise NotImplementedError
+
+
+class StabilizerMeasurement:
+    """Utilities for stabilizer measurements."""
+
+    def measure(self, circuit: QuantumCircuit):
+        """Return syndrome information for ``circuit``."""
+        raise NotImplementedError

--- a/src/quantum/advanced/noise_models.py
+++ b/src/quantum/advanced/noise_models.py
@@ -1,0 +1,20 @@
+"""Simplified noise model abstractions."""
+
+from quantum import QuantumCircuit
+
+
+class NoiseModel:
+    """Base class for circuit noise models."""
+
+    def apply(self, circuit: QuantumCircuit) -> None:
+        raise NotImplementedError
+
+
+class DepolarizingChannel(NoiseModel):
+    """Depolarizing channel affecting all qubits equally."""
+
+    def __init__(self, probability: float):
+        self.p = probability
+
+    def apply(self, circuit: QuantumCircuit) -> None:
+        raise NotImplementedError

--- a/src/quantum/advanced/variational.py
+++ b/src/quantum/advanced/variational.py
@@ -1,0 +1,20 @@
+"""Templates for variational quantum algorithms."""
+
+
+class VariationalCircuit:
+    """Base class for parameterized circuits."""
+
+    def __init__(self, num_qubits: int, parameters):
+        self.num_qubits = num_qubits
+        self.parameters = list(parameters)
+
+    def construct(self):
+        """Construct the circuit using current parameters."""
+        raise NotImplementedError
+
+
+class Optimizer:
+    """Simple optimizer interface for variational circuits."""
+
+    def step(self, objective_fn, params):
+        raise NotImplementedError

--- a/src/quantum/circuit.py
+++ b/src/quantum/circuit.py
@@ -88,3 +88,7 @@ class QuantumCircuit:
         """Return a bitstring measurement of the entire register."""
         result = self.measure()
         return bin(result)[2:].zfill(self.num_qubits)
+
+    def probabilities(self):
+        """Return the probability of each computational basis state."""
+        return np.abs(self.state) ** 2

--- a/src/quantum/gates.py
+++ b/src/quantum/gates.py
@@ -12,3 +12,10 @@ I = np.eye(2, dtype=complex)
 S = np.array([[1, 0], [0, 1j]], dtype=complex)
 T = np.array([[1, 0], [0, np.exp(1j * np.pi / 4)]], dtype=complex)
 
+
+def RZ(theta: float) -> np.ndarray:
+    """Return a rotation about the Z axis by ``theta`` radians."""
+    return np.array(
+        [[np.exp(-1j * theta / 2), 0], [0, np.exp(1j * theta / 2)]], dtype=complex
+    )
+


### PR DESCRIPTION
## Summary
- add RZ gate and export in `quantum` package
- expose probability helper in `QuantumCircuit`
- implement simple phase estimation algorithm and example
- document new demo and advanced skeleton in README
- scaffold `quantum.advanced` package for future features

## Testing
- `pip install numpy==1.26.4`
- `PYTHONPATH=src python3 src/grover_example.py`
- `PYTHONPATH=src python3 src/shor.py`
- `PYTHONPATH=src python3 src/phase_estimation_example.py`
- `pytest -q`